### PR TITLE
Removing empty or nil options from query options

### DIFF
--- a/lib/totango/event.rb
+++ b/lib/totango/event.rb
@@ -25,7 +25,7 @@ module Totango
         :sdr_odn => account_name, # A human readable name for the account (will be used on Totango’s UI and reports)
         :sdr_a => activity, # Name of the activity the user performed
         :sdr_m => self.module, # Name of the module the user is using within the application
-      }
+      }.reject { |k,v| v.nil? || v.empty? }
     end
 
     def to_url

--- a/lib/totango/event.rb
+++ b/lib/totango/event.rb
@@ -25,7 +25,7 @@ module Totango
         :sdr_odn => account_name, # A human readable name for the account (will be used on Totango’s UI and reports)
         :sdr_a => activity, # Name of the activity the user performed
         :sdr_m => self.module, # Name of the module the user is using within the application
-      }.reject { |k,v| v.nil? || v.empty? }
+      }.reject { |k,v| v.nil? || v.to_s.empty? }
     end
 
     def to_url

--- a/spec/totango/event_spec.rb
+++ b/spec/totango/event_spec.rb
@@ -6,7 +6,7 @@ describe Totango::Event do
     subject {
       described_class.new({
         :service_id => "SP-xxxxyy",
-        :account_id => "u12214",
+        :account_id => 12214,
         :account_name => "Barksdale+Industries",
         :username => "avon@barksdale.com",
         :activity => "Login",
@@ -18,7 +18,7 @@ describe Totango::Event do
       it "builds a query hash for a Totango pixel URL" do
         expect( subject.query_options ).to eq({
           :sdr_s => "SP-xxxxyy",
-          :sdr_o => "u12214",
+          :sdr_o => 12214,
           :sdr_odn => "Barksdale+Industries",
           :sdr_u => "avon@barksdale.com",
           :sdr_a => "Login",
@@ -37,7 +37,7 @@ describe Totango::Event do
         query_options = Hash[URI.decode_www_form(url.query)]
         expect( query_options ).to eq({
           "sdr_s" => "SP-xxxxyy",
-          "sdr_o" => "u12214",
+          "sdr_o" => "12214",
           "sdr_odn" => "Barksdale+Industries",
           "sdr_u" => "avon@barksdale.com",
           "sdr_a" => "Login",

--- a/spec/totango/event_spec.rb
+++ b/spec/totango/event_spec.rb
@@ -2,46 +2,84 @@ require 'spec_helper'
 
 describe Totango::Event do
 
-  subject {
-    described_class.new({
-      :service_id => "SP-xxxxyy",
-      :account_id => "u12214",
-      :account_name => "Barksdale+Industries",
-      :username => "avon@barksdale.com",
-      :activity => "Login",
-      :module => "Application"
-    })
-  }
-
-  describe "#query_options" do
-    it "builds a query hash for a Totango pixel URL" do
-      expect( subject.query_options ).to eq({
-        :sdr_s => "SP-xxxxyy",
-        :sdr_o => "u12214",
-        :sdr_odn => "Barksdale+Industries",
-        :sdr_u => "avon@barksdale.com",
-        :sdr_a => "Login",
-        :sdr_m => "Application"
+  describe "with all options set" do
+    subject {
+      described_class.new({
+        :service_id => "SP-xxxxyy",
+        :account_id => "u12214",
+        :account_name => "Barksdale+Industries",
+        :username => "avon@barksdale.com",
+        :activity => "Login",
+        :module => "Application"
       })
+    }
+
+    describe "#query_options" do
+      it "builds a query hash for a Totango pixel URL" do
+        expect( subject.query_options ).to eq({
+          :sdr_s => "SP-xxxxyy",
+          :sdr_o => "u12214",
+          :sdr_odn => "Barksdale+Industries",
+          :sdr_u => "avon@barksdale.com",
+          :sdr_a => "Login",
+          :sdr_m => "Application"
+        })
+      end
+    end
+
+    describe "#to_url" do
+      it "builds a Totango pixel URL" do
+        url = URI.parse( subject.to_url )
+
+        expect( url.host ).to eq( 'sdr.totango.com' )
+        expect( url.path ).to eq( "/pixel.gif/" )
+
+        query_options = Hash[URI.decode_www_form(url.query)]
+        expect( query_options ).to eq({
+          "sdr_s" => "SP-xxxxyy",
+          "sdr_o" => "u12214",
+          "sdr_odn" => "Barksdale+Industries",
+          "sdr_u" => "avon@barksdale.com",
+          "sdr_a" => "Login",
+          "sdr_m" => "Application"
+        })
+      end
     end
   end
 
-  describe "#to_url" do
-    it "builds a Totango pixel URL" do
-      url = URI.parse( subject.to_url )
-
-      expect( url.host ).to eq( 'sdr.totango.com' )
-      expect( url.path ).to eq( "/pixel.gif/" )
-
-      query_options = Hash[URI.decode_www_form(url.query)]
-      expect( query_options ).to eq({
-        "sdr_s" => "SP-xxxxyy",
-        "sdr_o" => "u12214",
-        "sdr_odn" => "Barksdale+Industries",
-        "sdr_u" => "avon@barksdale.com",
-        "sdr_a" => "Login",
-        "sdr_m" => "Application"
+  describe "with a subset of options set" do
+    subject {
+      described_class.new({
+        :service_id => "SP-xxxxyy",
+        :account_id => "u12214",
+        :account_name => "Barksdale+Industries"
       })
+    }
+
+    describe "#query_options" do
+      it "builds a query hash for a Totango pixel URL" do
+        expect( subject.query_options ).to eq({
+          :sdr_s => "SP-xxxxyy",
+          :sdr_o => "u12214",
+          :sdr_odn => "Barksdale+Industries"
+        })
+      end
+    end
+
+    describe "#to_url" do
+      it "builds a Totango pixel URL" do
+        url = URI.parse( subject.to_url )
+
+        expect( url.host ).to eq( 'sdr.totango.com' )
+        expect( url.path ).to eq( "/pixel.gif/" )
+
+        query_options = Hash[URI.decode_www_form(url.query)]
+        expect( query_options ).to eq({
+          "sdr_s" => "SP-xxxxyy",
+          "sdr_o" => "u12214",
+          "sdr_odn" => "Barksdale+Industries"
+        })
+      end
     end
   end
 


### PR DESCRIPTION
Totango will silently fail if there are empty values sent in the query strings. This PR removes any such values from the query options.
